### PR TITLE
Fix: Portal Reloaded Crashing And Time Portal Alias

### DIFF
--- a/autoexec.cfg
+++ b/autoexec.cfg
@@ -28,9 +28,10 @@ sar_demo_blacklist_addcmd exit
 sar_demo_blacklist_addcmd sar_exit
 sar_demo_blacklist_addcmd sar_on_
 
-// Stop the game from going to sleep when it loses focus
+// Stop the game from going to sleep when it loses focus. Disabled for reloaded due to crashes.
 sar_disable_no_focus_sleep 1
-snd_mute_losefocus 0
+cond "game=reloaded" snd_mute_losefocus 1
+cond "!game=reloaded" snd_mute_losefocus 0
 
 // Allow OOB vision
 r_portal_use_pvs_optimization 0

--- a/map_detect/reloaded.cfg
+++ b/map_detect/reloaded.cfg
@@ -23,3 +23,6 @@ cond "map=sp_a1_pr_map_012" setmap 1 finale
 
 svar_set chapter_name portal-reloaded
 svar_set course_name  portal-reloaded
+
+alias "+zoom" "ent_fire @caller Trigger"
+alias "+remote_view" "ent_fire @toggle_ghosting Trigger"


### PR DESCRIPTION
made snd_mute_losefocus 0 not apply for reloaded as it causes a crash and added aliases for time portal