### PR TITLE
fix: aptag and mel categories are RTA

### DIFF
--- a/cats/fullgame.cfg
+++ b/cats/fullgame.cfg
@@ -1,7 +1,6 @@
 // Speedrun category
 cond "game=portal2 | game=srm" sar_speedrun_category Singleplayer
-cond "game=reloaded" sar_speedrun_category RTA
-cond "game=mel | game=aptag" sar_speedrun_category "Chambers RTA"
+cond "game=reloaded | game=mel | game=aptag" sar_speedrun_category RTA
 svar_set no_mtriggers 1
 
 // Speedrun timing


### PR DESCRIPTION
see also lines 8 and 69 (nice) of [the category presets](https://github.com/p2sr/SourceAutoRecord/blob/2ab640c52adc0b7d8262c350a729dd61926b3d5d/src/Features/Speedrun/CategoriesPreset.cpp)