### PR TITLE
Added comments explaining the loop of category detection

### DIFF
--- a/autoexec.cfg
+++ b/autoexec.cfg
@@ -137,9 +137,17 @@ cond "game=reloaded"           sar_on_load exec map_detect/reloaded
 
 // Black magic to create categories
 sar_function __force_warn echo "Forcing category $1. Run 'auto' to re-enable automatic category selection."
+// Stores the number of categories (increased whenever a category is added)
 svar_set __detect_len 0
+// Iterate over all categories
+// $__loopi is the is the number of iterations, $__loopcmd gets executed every loop
 sar_function __cat_loop     "svar_set __loopcmd $'$1$'; svar_set __loopi $2; __cat_loop_h1"
+// Each iteration, $__loopcmd gets executed and $__loopi gets decremented until it reaches 0
 sar_function __cat_loop_h1  "cond $'!var:__loopi=0$' $'$__loopcmd; svar_sub __loopi 1; __cat_loop_h1$'"
+// The loop itself. $__detect_cur is the iterator; using the loop in the
+// line above, we execute __detect_$__detect_cur with an incrementing
+// $__detect_cur, $__detect_len times (__detect_0, __detect_1, etc).
+// If the category has changed, stop demo recording
 sar_function __detect "svar_set __old_category $category; svar_set category $__detect_default; svar_set __detect_cur 0; __cat_loop $'sar_expand __detect_$$__detect_cur; svar_add __detect_cur 1$' $__detect_len; sar_expand cond $'!var:category=$$__old_category$' stop"
 // HACKHACK: we don't record demos in Mel
 cond "game=mel"  sar_alias __record nop


### PR DESCRIPTION
As I read the `autoexec.cfg`, I noticed that I had a lot of trouble understanding the “black magic” of category creation. So I thought I might add some comments that further explain what is actually going on.

I tried to adapt the comment and code style as good as possible though I'm ready to revise it.