### PR TITLE
fix: don't allow chapter ils in reloaded

### DIFF
--- a/autoexec.cfg
+++ b/autoexec.cfg
@@ -240,8 +240,8 @@ sar_alias non_cm_only cond "!var:category=sp_cm & !var:category=coop_cm"
 cond "game=portal2" exec mtriggers/mtriggers
 
 // Same for the chapter categories
-sar_function run_cur_chapter "svar_set __cur_chapter $'$chapter$'; chapter_il"
-sar_function run_chapter     "svar_set __cur_chapter $'$1$'; chapter_il"
+cond "!game=reloaded" sar_function run_cur_chapter "svar_set __cur_chapter $'$chapter$'; chapter_il"
+cond "!game=reloaded" sar_function run_chapter     "svar_set __cur_chapter $'$1$'; chapter_il"
 cond "game=portal2 | game=srm" exec chapter_cats/portal2
 cond "game=aptag"              exec chapter_cats/aptag
 cond "game=mel"                exec chapter_cats/mel


### PR DESCRIPTION
because they don't exist