### PR TITLE
fix: cm prompt edge case

### DIFF
--- a/cm_ghost.cfg
+++ b/cm_ghost.cfg
@@ -19,12 +19,12 @@ sar_alias __tmp_toast_restore "__tmp_cvar_restore sar_toast_x; __tmp_cvar_restor
 
 // Aliases for actually doing the prompt
 sar_toast_tag_set_duration cm_ghost_warning forever
-sar_alias __cm_ghost_warning "svar_set __cm_ghost_warning 1; sar_toast_tag_dismiss_all speedrun; __tmp_toast_save; sar_toast_font 68; sar_toast_width 500; sar_toast_setpos top center; __tmp_bind_save y; __tmp_bind_save n; bind y __cm_ghost_accept; bind n __cm_ghost_reject; __cm_ghost_warning_text"
+sar_alias __cm_ghost_warning      cond "!var:__cm_ghost_warning=1" "svar_set __cm_ghost_warning 1; sar_toast_tag_dismiss_all speedrun; __tmp_toast_save; sar_toast_font 68; sar_toast_width 500; sar_toast_setpos top center; __tmp_bind_save y; __tmp_bind_save n; bind y __cm_ghost_accept; bind n __cm_ghost_reject; __cm_ghost_warning_text"
+sar_alias __cm_ghost_warning_done cond  "var:__cm_ghost_warning=1" "svar_set __cm_ghost_warning 0; sar_toast_tag_dismiss_all cm_ghost_warning; __tmp_toast_restore; __tmp_bind_restore y; __tmp_bind_restore n"
 sar_function __cm_ghost_warning_text "sar_toast_create cm_ghost_warning $'This can be changed later via the 'cm_ghost_server' svar.$'; sar_toast_create cm_ghost_warning $'Press N to stay disconnected$'; sar_toast_create cm_ghost_warning $'Press Y to connect to the server$'; sar_toast_create cm_ghost_warning $'There is a world-wide 'ghost server' that players can connect to and chat on while playing Challenge Mode.$'; echo $'----> Press Y or N ingame, not here! <----$'"
 sar_alias __cm_ghost_accept "svar_set cm_ghost_server 1; __cm_ghost_warning_done; __cm_ghost_tryconnect"
 sar_alias __cm_ghost_reject "svar_set cm_ghost_server 0; __cm_ghost_warning_done"
-sar_alias __cm_ghost_warning_done "svar_set __cm_ghost_warning 0; sar_toast_tag_dismiss_all cm_ghost_warning; __tmp_toast_restore; __tmp_bind_restore y; __tmp_bind_restore n"
-sar_on_exit cond "var:__cm_ghost_warning=1" "__cm_ghost_warning_done"
+sar_on_exit __cm_ghost_warning_done
 
 // Show the prompt on first load if we've not decided whether to connect
 sar_on_load cond "var:category=sp_cm & var:cm_ghost_server=-1" "__cm_ghost_warning"


### PR DESCRIPTION
If the user goes through a load with the prompt active, the binds/cvars will be saved over and lost