### PR TITLE
Add `cm_hud_behavior` svar for recent +leaderboard changes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,8 @@ For instance, `svar_set no_dialogue_toasts 1` will disable dialogue fade toasts.
 | `no_taunt_toasts_coop`     |    0    | When 1, disable `[taunt]` toasts in coop.
 | `show_map_name_coop`       |    1    | When 1, show the current map name in coop.
 | `show_blank_fades`         |    1    | When 1, show `[no fade]` for maps that don't have a dialogue fade.
-| `coop_cm_enable_hud`       |    1    | When 1, don't disable the CM stats HUD in coop.
+| `cm_hud_behavior`          |    1    | Changes the behavior of `sar_disable_challenge_stats_hud`. -1 - Closes instantly, 0 - Doesn't automatically close, 1 - Closes after flashing.
+| `coop_cm_enable_hud`       |    1    | When 1, don't disable the CM stats HUD in coop. Otherwise, stats hud reflects behavior of `cm_hud_behavior`.
 | `coop_no_stopvideos`       |    0    | When 1, don't run `stopvideos` on every coop load.
 | `coop_no_remoteview`       |    0    | When 1, don't enable remote view on every coop load.
 | `coop_no_remoteview_lobby` |    0    | When 1, don't enable remote view on coop loads into the Lobby.<br>Turn this on if you experience lag in the Lobby.

--- a/srconfigs/cats/coop_cm.cfg
+++ b/srconfigs/cats/coop_cm.cfg
@@ -18,9 +18,9 @@ conds "?cm_keep_pb_only=1" "sar_challenge_autostop 3" "sar_challenge_autostop 2"
 sar_fast_load_preset full
 
 // We don't disable the challenge status HUD in coop as this can cause timing
-// issues
+// issues. Also supports HUD behavior changing for those that want it.
 cond  "?coop_cm_enable_hud=1" sar_disable_challenge_stats_hud 0
-cond "!?coop_cm_enable_hud=1" sar_disable_challenge_stats_hud 1
+cond "!?coop_cm_enable_hud=1" sar_expand sar_disable_challenge_stats_hud $cm_hud_behavior
 
 // Prevent accidental CM wrongwarp
 sar_cm_rightwarp 1

--- a/srconfigs/cats/sp_cm.cfg
+++ b/srconfigs/cats/sp_cm.cfg
@@ -17,8 +17,8 @@ conds "?cm_keep_pb_only=1" "sar_challenge_autostop 3" "sar_challenge_autostop 2"
 // Fast loads
 sar_fast_load_preset full
 
-// Disable the challenge stats HUD in SP only
-sar_disable_challenge_stats_hud 1
+// Disable the challenge stats HUD depending on svar
+sar_expand sar_disable_challenge_stats_hud $cm_hud_behavior
 
 // Prevent accidental CM wrongwarp
 sar_cm_rightwarp 1

--- a/srconfigs/srconfigs.cfg
+++ b/srconfigs/srconfigs.cfg
@@ -117,6 +117,7 @@ __set_if_empty_persist  no_dialogue_toasts_coop 0
 __set_if_empty_persist     no_taunt_toasts_coop 0
 __set_if_empty_persist       show_map_name_coop 1
 __set_if_empty_persist         show_blank_fades 1
+__set_if_empty_persist          cm_hud_behavior 1
 __set_if_empty_persist       coop_cm_enable_hud 1
 __set_if_empty_persist       coop_no_stopvideos 0
 __set_if_empty_persist       coop_no_remoteview 0


### PR DESCRIPTION
srconfigs by default only has `sar_disable_challenge_stats_hud 1` in sp_cm, and an svar to toggle between 0 and 1 in coop_cm. Added an svar to be able to change back to old behavior.