### PR TITLE
Fixed srconfigs setting "sar_record_at -1" on all categories.

### DIFF
--- a/srconfigs/srconfigs.cfg
+++ b/srconfigs/srconfigs.cfg
@@ -276,7 +276,7 @@ sar_on_config_exec conds "?enable_menu_transitions=1" "ui_transition_effect 1" "
 
 // If we're suppressing recording, unset sar_record_at
 sar_on_load cond "?__suppress_record=1" sar_record_at -1
-sar_on_load cond "game=mel" non_cm_only sar_record_at -1
+sar_on_load cond "game=mel" cat_only fullgame sar_record_at -1
 
 // Create the built-in categories
 add_cat fullgame


### PR DESCRIPTION
In its current form srconfigs does "sar_record_at -1" even if you're using a different category like tas or il where you might want different recording settings instead of no demo recording.