### PR TITLE
feat: improved "il" categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,11 @@ These configuration files support the following speedrun categories:
 - Solo Coop (`solocoop`)
 - Coop Challenge Mode (`coop_cm`)
 - Chapter ILs (`chapter_il`)
+- Individual Levels (`il`)
 - Celeste Mode (`celeste` - P2SM only)
 - Reverse Mod (`reverse` - P2SM only)
-- Workshop (`workshop`)
+- Workshop Maps (`workshop`)
+- Bhop Maps (`bhop`)
 
 To manually switch to a category, simply run the category name as a
 command; for instance, the command `anypc` activates the Any% category.
@@ -39,8 +41,11 @@ After manually selecting a category, the automatic selection will not be
 re-enabled until the `auto` command is ran.
 
 Note that in mods, only the `fullgame` category exists from the above.
-Some mods also add a simple `il` category for doing individual level
-runs.
+
+An `il` category is also added for individual workshop maps as well as
+manually-downloaded chambers, while `workshop` should be used for multiple
+workshop maps (MRCC). The `bhop` category specifically times maps that include
+the Timer prefab often seen on bhop maps.
 
 ## Binds
 

--- a/srconfigs/cats/bhop.cfg
+++ b/srconfigs/cats/bhop.cfg
@@ -1,6 +1,6 @@
 // Speedrun category
+sar_speedrun_category "Bhop"
 svar_set no_mtriggers 1
-sar_toast_tag_dismiss_all speedrun
 
 // Speedrun timing
 sar_speedrun_offset 0
@@ -9,13 +9,16 @@ sar_speedrun_start_on_load 1
 sar_speedrun_smartsplit 1
 
 // Demo recording
-sar_autorecord 1
-sar_expand sar_expand sar_record_prefix "$demo_folder_name/workshop/$workshop_demo_name"
-sar_speedrun_autostop 0
+sar_autorecord -1
+sar_expand sar_expand sar_record_prefix "$demo_folder_name/bhop/$il_demo_name"
+sar_speedrun_autostop 2
 sar_challenge_autostop 0
 
 // Fast loads
 sar_fast_load_preset full
+
+// Disable the challenge stats HUD in SP only
+sar_disable_challenge_stats_hud 1
 
 // Prevent accidental CM wrongwarp
 sar_cm_rightwarp 1
@@ -24,4 +27,4 @@ sar_cm_rightwarp 1
 developer 1
 
 // Category-specific aliases
-sar_alias do_reset "restart_level"
+sar_alias do_reset "sar_speedrun_reset; restart_level"

--- a/srconfigs/cats/il.cfg
+++ b/srconfigs/cats/il.cfg
@@ -1,4 +1,5 @@
 // Speedrun category
+sar_speedrun_category "Individual Levels"
 svar_set no_mtriggers 1
 
 // Speedrun timing

--- a/srconfigs/cats/workshop.cfg
+++ b/srconfigs/cats/workshop.cfg
@@ -1,6 +1,6 @@
 // Speedrun category
-sar_speedrun_category "Bhop"
 svar_set no_mtriggers 1
+sar_toast_tag_dismiss_all speedrun
 
 // Speedrun timing
 sar_speedrun_offset 0
@@ -9,16 +9,13 @@ sar_speedrun_start_on_load 1
 sar_speedrun_smartsplit 1
 
 // Demo recording
-sar_autorecord -1
-sar_expand sar_expand sar_record_prefix "$demo_folder_name/bhop/$il_demo_name"
-sar_speedrun_autostop 2
+sar_autorecord 1
+sar_expand sar_expand sar_record_prefix "$demo_folder_name/workshop/$workshop_demo_name"
+sar_speedrun_autostop 0
 sar_challenge_autostop 0
 
 // Fast loads
 sar_fast_load_preset full
-
-// Disable the challenge stats HUD in SP only
-svar_set cm_hud_behavior -1 
 
 // Prevent accidental CM wrongwarp
 sar_cm_rightwarp 1
@@ -27,4 +24,4 @@ sar_cm_rightwarp 1
 developer 1
 
 // Category-specific aliases
-sar_alias do_reset "sar_speedrun_reset; restart_level"
+sar_alias do_reset "restart_level"

--- a/srconfigs/mkcats.cfg
+++ b/srconfigs/mkcats.cfg
@@ -1,7 +1,7 @@
 sar_speedrun_cc_start "Individual Levels" map=*
 sar_speedrun_cc_rule "Start" load action=start
 sar_speedrun_cc_rule "Finish" entity targetname=@relay_pti_level_end inputname=Trigger action=stop
-sar_speedrun_cc_rule "Flags" flags action=stop
+sar_speedrun_cc_rule "Flags" end action=stop
 sar_speedrun_cc_finish
 
 cond "game=portal2" sar_speedrun_cc_start "Bhop" map=*

--- a/srconfigs/mkcats.cfg
+++ b/srconfigs/mkcats.cfg
@@ -1,3 +1,14 @@
+sar_speedrun_cc_start "Individual Levels" map=*
+sar_speedrun_cc_rule "Start" load action=start
+sar_speedrun_cc_rule "Finish" entity targetname=@relay_pti_level_end inputname=Trigger action=stop
+sar_speedrun_cc_rule "Flags" flags action=stop
+sar_speedrun_cc_finish
+
+cond "game=portal2" sar_speedrun_cc_start "Bhop" map=*
+cond "game=portal2" sar_speedrun_cc_rule  "Start" entity action=start targetname=timerinst_relay-start inputname=Trigger
+cond "game=portal2" sar_speedrun_cc_rule  "Finish" entity action=stop targetname=timerinst_relay-stop inputname=Trigger
+cond "game=portal2" sar_speedrun_cc_finish
+
 cond "game=srm" sar_speedrun_cc_start "Reverse"
 cond "game=srm" sar_speedrun_cc_rule "Start" entity targetname=ending_vehicle inputname=ExitVehicle map=sp_a4_finale4 action=start
 cond "game=srm" sar_speedrun_cc_rule "Finish" entity targetname=rev_sleep_button inputname=Use map=sp_a1_intro1 action=stop 

--- a/srconfigs/srconfigs.cfg
+++ b/srconfigs/srconfigs.cfg
@@ -287,15 +287,16 @@ sar_on_load cond "game=mel" cat_only fullgame sar_record_at -1
 
 // Create the built-in categories
 add_cat fullgame
+add_cat il
 cond "game=portal2" add_cat anypc
 cond "game=portal2 | game=mel" add_cat sp_cm
 cond "game=portal2 | game=reloaded" add_cat amc
 cond "game=portal2" add_cat ac
 cond "game=portal2" add_cat coop_cm
 cond "game=portal2 | game=reloaded" add_cat solocoop
+cond "game=portal2" add_cat bhop
 cond "game=srm" add_cat celeste
 cond "game=srm" add_cat reverse
-cond "game=mel | game=aptag | game=reloaded" add_cat il
 cond "game=portal2 | game=srm | game=mel | game=aptag" add_cat chapter_il
 add_cat workshop
 


### PR DESCRIPTION
- Consolidated "workshop" and "il" categories, with timing and demos now tied to a SAR category (load, flags/rate screen).

- Added "bhop" category, with timing and demos tied to a SAR category (KranK Timer start/stop)

- Enabled "il" to be automatically added when in any game, and enabled "bhop" to be automatically added when in Portal 2.