### PR TITLE
feat: Add practice category for ad-hoc triggers

### DIFF
--- a/srconfigs/cats/practice.cfg
+++ b/srconfigs/cats/practice.cfg
@@ -1,0 +1,9 @@
+// Practice category - for ad-hoc trigger testing
+// Used by sar_speedrun_adhoc_trigger
+
+sar_speedrun_offset 0
+sar_speedrun_time_pauses 0
+sar_speedrun_start_on_load 2
+sar_speedrun_smartsplit 1
+sar_speedrun_draw_triggers 1
+sar_speedrun_triggers_info 0

--- a/srconfigs/cats/practice.cfg
+++ b/srconfigs/cats/practice.cfg
@@ -12,4 +12,13 @@ sar_speedrun_offset 0
 sar_speedrun_time_pauses 0
 sar_speedrun_start_on_load 2
 sar_speedrun_smartsplit 1
-sar_speedrun_draw_triggers 1
+
+// Toast colors for split times
+sar_toast_tag_set_color adhoc_best 00FF00
+sar_toast_tag_set_color adhoc_slow FF6666
+
+// Bigger toasts for practice
+sar_toast_font 33
+
+// Disable default speedrun toast (we show our own delta instead)
+sar_toast_tag_set_duration speedrun 0

--- a/srconfigs/cats/practice.cfg
+++ b/srconfigs/cats/practice.cfg
@@ -1,9 +1,15 @@
 // Practice category - for ad-hoc trigger testing
 // Used by sar_speedrun_adhoc_trigger
 
+// Enable cheats (needed for trigger visualization)
+sv_cheats 1
+
+// Show triggers without text clutter
+sar_speedrun_draw_triggers 2
+
+// Timer settings
 sar_speedrun_offset 0
 sar_speedrun_time_pauses 0
 sar_speedrun_start_on_load 2
 sar_speedrun_smartsplit 1
 sar_speedrun_draw_triggers 1
-sar_speedrun_triggers_info 0

--- a/srconfigs/srconfigs.cfg
+++ b/srconfigs/srconfigs.cfg
@@ -324,6 +324,7 @@ cond "game=srm" add_cat celeste
 cond "game=srm" add_cat reverse
 cond "game=portal2 | game=srm | game=mel | game=aptag" add_cat chapter_il
 add_cat workshop
+add_cat practice
 
 // Add the auto-selection for all the built-in categories
 default_cat fullgame


### PR DESCRIPTION
## Summary
Adds a new minimal "practice" category used by SAR's `sar_speedrun_adhoc_trigger` feature.

## Changes
- New file: srconfigs/cats/practice.cfg
- Added `add_cat practice` to srconfigs.cfg

Companion PR to SAR's ad-hoc trigger feature.